### PR TITLE
Accept json 2.0.1 version and future minor version upgrades

### DIFF
--- a/src/main/java/io/jenkins/plugins/llvm/LLVMCovReportDocumentConverter.java
+++ b/src/main/java/io/jenkins/plugins/llvm/LLVMCovReportDocumentConverter.java
@@ -18,7 +18,7 @@ public class LLVMCovReportDocumentConverter extends JSONDocumentConverter {
     @Override
     protected Document convert(JsonNode report, Document document) throws CoverageException {
         // only support 2.0.x version now
-        if (!report.get("version").asText().equals("2.0.")) {
+        if (!report.get("version").asText().startsWith("2.0.")) {
             throw new CoverageException("Unsupported Json file - version must be 2.0.x");
         }
 

--- a/src/main/java/io/jenkins/plugins/llvm/LLVMCovReportDocumentConverter.java
+++ b/src/main/java/io/jenkins/plugins/llvm/LLVMCovReportDocumentConverter.java
@@ -17,9 +17,9 @@ import java.util.stream.StreamSupport;
 public class LLVMCovReportDocumentConverter extends JSONDocumentConverter {
     @Override
     protected Document convert(JsonNode report, Document document) throws CoverageException {
-        // only support 2.0.0 version now
-        if (!report.get("version").asText().equals("2.0.0")) {
-            throw new CoverageException("Unsupported Json file - version must be 2.0.0");
+        // only support 2.0.x version now
+        if (!report.get("version").asText().equals("2.0.")) {
+            throw new CoverageException("Unsupported Json file - version must be 2.0.x");
         }
 
         if (!report.get("type").asText().equals("llvm.coverage.json.export")) {


### PR DESCRIPTION
This change no longer checks the minor version numbner in the json version.
This way the current exported json version 2.0.1 from llvm-cov will be accepted.

Issue: #12 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
